### PR TITLE
feat: add `addDeploymentTargetByDomainId`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ set shell:=["bash", "-uc"]
 set dotenv-load
 
 # build the contracts
-build:
+build: fmt
     forge build
 
 # format source
@@ -10,7 +10,7 @@ fmt:
     forge fmt
 
 # run unit tests
-test:
+test: fmt
     forge test
 
 # watches the directory for changes and rebuilds.

--- a/src/CrosschainDeployScript.sol
+++ b/src/CrosschainDeployScript.sol
@@ -15,7 +15,11 @@ contract CrosschainDeployScript is Script {
     // this address is the same across all chains
     address private crosschainDeployContractAddress = 0x85d62AD850B322152BF4ad9147bfBF097DA42217;
 
-    enum Env{ UNKNOWN, TESTNET, MAINNET }
+    enum Env {
+        UNKNOWN,
+        TESTNET,
+        MAINNET
+    }
 
     struct NetworkIds {
         uint8 InternalDomainId;
@@ -26,8 +30,9 @@ contract CrosschainDeployScript is Script {
     // given a string, obtain the domain ID;
     // https://www.notion.so/chainsafe/Testnet-deployment-0483991cf1ac481593d37baf8d48712a
     mapping(string => NetworkIds) private _stringToNetworkIds;
+    mapping(uint8 => string) private _domainIdToDeploymentTargets;
 
-   Env env = Env.UNKNOWN;
+    Env env = Env.UNKNOWN;
 
     // NOTE: All three of these need to be stored in the same order since they've
     //      a shared index. Storing them in a mapping isn't gas-efficient since I'd
@@ -59,18 +64,25 @@ contract CrosschainDeployScript is Script {
         _stringToNetworkIds["mumbai"] = NetworkIds(7, 80001, Env.TESTNET);
         _stringToNetworkIds["arbitrum-sepolia"] = NetworkIds(8, 421614, Env.TESTNET);
         _stringToNetworkIds["gnosis-chiado"] = NetworkIds(9, 10200, Env.TESTNET);
+
+        _domainIdToDeploymentTargets[2] = "sepolia";
+        _domainIdToDeploymentTargets[5] = "cronos-testnet";
+        _domainIdToDeploymentTargets[6] = "holesky";
+        _domainIdToDeploymentTargets[7] = "mumbai";
+        _domainIdToDeploymentTargets[8] = "arbitrum-sepolia";
+        _domainIdToDeploymentTargets[9] = "gnosis-chiado";
         setSalt(generateSalt());
     }
 
-    function _convertDeploymentTargetToNetworkIds(string memory deploymentTarget)
-        private
-        returns (NetworkIds memory)
-    {
+    function _convertDeploymentTargetToNetworkIds(string memory deploymentTarget) private returns (NetworkIds memory) {
         NetworkIds memory deploymentTargetNetworkIds = _stringToNetworkIds[deploymentTarget];
-        if(env == Env.UNKNOWN) {
+        if (env == Env.UNKNOWN) {
             env = deploymentTargetNetworkIds.env;
         } else {
-            require(env == deploymentTargetNetworkIds.env, "Deployment target is not in the same env as previous deployment targets");
+            require(
+                env == deploymentTargetNetworkIds.env,
+                "Deployment target is not in the same env as previous deployment targets"
+            );
         }
         uint8 deploymentTargetDomainId = deploymentTargetNetworkIds.InternalDomainId;
         require(deploymentTargetDomainId != 0, "Invalid deployment target");
@@ -78,12 +90,21 @@ contract CrosschainDeployScript is Script {
     }
 
     /**
-    * Obtains and stores contract bytecode by artifact path
-    * @param artifactPath Contract name in the form of `ContractFile.sol`, if the name of the contract and the file are the same, or `ContractFile.sol:ContractName` if they are different.
-    */
+     * Internal function to convert the internal sygma ID to the NetworkId object
+     */
+    function _convertDomainIdToNetworkIds(uint8 internalDomainId) private returns (NetworkIds memory) {
+        string memory deploymentTarget = _domainIdToDeploymentTargets[internalDomainId];
+        return _convertDeploymentTargetToNetworkIds(deploymentTarget);
+    }
+
+    /**
+     * Obtains and stores contract bytecode by artifact path
+     * @param artifactPath Contract name in the form of `ContractFile.sol`, if the name of the contract and the file are the same, or `ContractFile.sol:ContractName` if they are different.
+     */
     function setContract(string calldata artifactPath) public {
         contractBytecode = vm.getCode(artifactPath);
     }
+
     function setContractBytecode(bytes calldata _contractBytecode) public {
         contractBytecode = _contractBytecode;
     }
@@ -103,9 +124,23 @@ contract CrosschainDeployScript is Script {
     }
 
     /**
-    * Returns array of bridge fees (one for each deployment target or empty if just current chain deployment) 
-    */
-    function getFees(uint256 gasLimit, bool isUniquePerChain) public view returns(uint256[] memory) {
+     * This function takes the Sygma domain ID and replicates the behaviour of `addDeploymentTarget`.
+     * These functions can be used alternately, depending on developer preference.
+     */
+    function addDeploymentTargetByDomainId(uint8 internalDomainId, bytes memory constructorArgs, bytes memory initData)
+        public
+    {
+        NetworkIds memory networkIds = _convertDomainIdToNetworkIds(internalDomainId);
+        _domainIds.push(networkIds.InternalDomainId);
+        _chainIds.push(networkIds.ChainId);
+        _constructorArgs.push(constructorArgs);
+        _initDatas.push(initData);
+    }
+
+    /**
+     * Returns array of bridge fees (one for each deployment target or empty if just current chain deployment)
+     */
+    function getFees(uint256 gasLimit, bool isUniquePerChain) public view returns (uint256[] memory) {
         require(contractBytecode.length > 0, "Please use setContract or setContractBytecode first");
         return ICrosschainDeployAdapter(crosschainDeployContractAddress).calculateDeployFee(
             contractBytecode, gasLimit, salt, isUniquePerChain, _constructorArgs, _initDatas, _domainIds
@@ -113,9 +148,9 @@ contract CrosschainDeployScript is Script {
     }
 
     /**
-    * Returns total bridge fee 
-    */
-    function getTotalFee(uint256 gasLimit, bool isUniquePerChain) public view returns(uint256) {
+     * Returns total bridge fee
+     */
+    function getTotalFee(uint256 gasLimit, bool isUniquePerChain) public view returns (uint256) {
         uint256[] memory fees = getFees(gasLimit, isUniquePerChain);
         uint256 totalFee;
         uint256 feesArrayLength = fees.length;
@@ -155,10 +190,10 @@ contract CrosschainDeployScript is Script {
             contractBytecode, gasLimit, salt, isUniquePerChain, _constructorArgs, _initDatas, _domainIds, fees
         );
         vm.stopBroadcast();
-        if(env == Env.TESTNET) {
+        if (env == Env.TESTNET) {
             console.log("You can track deployment progress at https://scan.test.buildwithsygma.com/transfer/<txHash>");
         }
-        if(env == Env.MAINNET) {
+        if (env == Env.MAINNET) {
             console.log("You can track deployment progress at https://scan.buildwithsygma.com/transfer/<txHash>");
         }
         address[] memory contractAddresses = new address[](_chainIds.length);
@@ -211,10 +246,12 @@ contract CrosschainDeployScript is Script {
      *     @param deploymentTarget the name of the network onto which to deploy the chain.
      *     @return Address where the contract will be deployed on this chain.
      */
-    function computeAddressForChain(address sender, bytes32 deploySalt, bool isUniquePerChain, string memory deploymentTarget)
-        external
-        returns (address)
-    {
+    function computeAddressForChain(
+        address sender,
+        bytes32 deploySalt,
+        bool isUniquePerChain,
+        string memory deploymentTarget
+    ) external returns (address) {
         NetworkIds memory networkIds = _convertDeploymentTargetToNetworkIds(deploymentTarget);
 
         return ICrosschainDeployAdapter(crosschainDeployContractAddress).computeContractAddressForChain(

--- a/src/CrosschainDeployScript.sol
+++ b/src/CrosschainDeployScript.sol
@@ -13,7 +13,7 @@ import {ICrosschainDeployAdapter} from "./interfaces/CrosschainDeployAdapterInte
 contract CrosschainDeployScript is Script {
     // this is the address of the original contract defined in chainsafe/hardhat-plugin-multichain-deploy
     // this address is the same across all chains
-    address private crosschainDeployContractAddress = 0x85d62AD850B322152BF4ad9147bfBF097DA42217;
+    address private crosschainDeployContractAddress = 0xD72f1165751c3B9C5952B19596A36354ac30FdBd;
 
     enum Env {
         UNKNOWN,

--- a/src/CrosschainDeployScript.sol
+++ b/src/CrosschainDeployScript.sol
@@ -58,20 +58,18 @@ contract CrosschainDeployScript is Script {
      * @notice Constructor, takes the contract name.
      */
     constructor() {
-        _stringToNetworkIds["sepolia"] = NetworkIds(2, 11155111, Env.TESTNET);
-        _stringToNetworkIds["cronos-testnet"] = NetworkIds(5, 338, Env.TESTNET);
-        _stringToNetworkIds["holesky"] = NetworkIds(6, 17000, Env.TESTNET);
-        _stringToNetworkIds["mumbai"] = NetworkIds(7, 80001, Env.TESTNET);
-        _stringToNetworkIds["arbitrum-sepolia"] = NetworkIds(8, 421614, Env.TESTNET);
-        _stringToNetworkIds["gnosis-chiado"] = NetworkIds(9, 10200, Env.TESTNET);
-
-        _domainIdToDeploymentTargets[2] = "sepolia";
-        _domainIdToDeploymentTargets[5] = "cronos-testnet";
-        _domainIdToDeploymentTargets[6] = "holesky";
-        _domainIdToDeploymentTargets[7] = "mumbai";
-        _domainIdToDeploymentTargets[8] = "arbitrum-sepolia";
-        _domainIdToDeploymentTargets[9] = "gnosis-chiado";
+        _addNetwork("sepolia", 2, 11155111, Env.TESTNET);
+        _addNetwork("cronos-testnet", 5, 338, Env.TESTNET);
+        _addNetwork("holesky", 6, 17000, Env.TESTNET);
+        _addNetwork("mumbai", 7, 80001, Env.TESTNET);
+        _addNetwork("arbitrum-sepolia", 8, 421614, Env.TESTNET);
+        _addNetwork("gnosis-chiado", 9, 10200, Env.TESTNET);
         setSalt(generateSalt());
+    }
+
+    function _addNetwork(string memory deploymentTarget, uint8 domainId, uint256 chainId, Env environ) private {
+        _stringToNetworkIds[deploymentTarget] = NetworkIds(domainId, chainId, environ);
+        _domainIdToDeploymentTargets[domainId] = deploymentTarget;
     }
 
     function _convertDeploymentTargetToNetworkIds(string memory deploymentTarget) private returns (NetworkIds memory) {

--- a/src/CrosschainDeployScript.sol
+++ b/src/CrosschainDeployScript.sol
@@ -67,12 +67,10 @@ contract CrosschainDeployScript is Script {
         setSalt(generateSalt());
     }
 
-
     function _addNetwork(string memory deploymentTarget, uint8 domainId, uint256 chainId, Env environ) private {
         _stringToNetworkIds[deploymentTarget] = NetworkIds(domainId, chainId, environ);
         _domainIdToDeploymentTargets[domainId] = deploymentTarget;
     }
-
 
     function _convertDeploymentTargetToNetworkIds(string memory deploymentTarget) private returns (NetworkIds memory) {
         NetworkIds memory deploymentTargetNetworkIds = _stringToNetworkIds[deploymentTarget];
@@ -90,7 +88,6 @@ contract CrosschainDeployScript is Script {
     }
 
     /**
-
      * Internal function to convert the internal sygma ID to the NetworkId object
      */
     function _convertDomainIdToNetworkIds(uint8 internalDomainId) private returns (NetworkIds memory) {
@@ -99,7 +96,6 @@ contract CrosschainDeployScript is Script {
     }
 
     /**
-
      * Obtains and stores contract bytecode by artifact path
      * @param artifactPath Contract name in the form of `ContractFile.sol`, if the name of the contract and the file are the same, or `ContractFile.sol:ContractName` if they are different.
      */
@@ -126,7 +122,6 @@ contract CrosschainDeployScript is Script {
     }
 
     /**
-
      * This function takes the Sygma domain ID and replicates the behaviour of `addDeploymentTarget`.
      * These functions can be used alternately, depending on developer preference.
      */

--- a/test/mocks/MockCrosschainDeployAdapter.sol
+++ b/test/mocks/MockCrosschainDeployAdapter.sol
@@ -23,11 +23,7 @@ contract MockCrosschainDeployAdapter {
      * @notice Computes the address where the contract will be deployed on specified chain.
      *     @return Address where the contract will be deployed on specified chain.
      */
-    function computeContractAddressForChain(address, bytes32, bool, uint256)
-        external
-        pure
-        returns (address)
-    {
+    function computeContractAddressForChain(address, bytes32, bool, uint256) external pure returns (address) {
         address newAddress;
         return newAddress;
     }
@@ -35,15 +31,11 @@ contract MockCrosschainDeployAdapter {
     /**
      * @notice Returns total amount of native currency needed for a deploy request.
      */
-    function calculateDeployFee(
-        bytes calldata,
-        uint256,
-        bytes32,
-        bool,
-        bytes[] memory,
-        bytes[] memory,
-        uint8[] memory
-    ) external pure returns (uint256[] memory fees) {
+    function calculateDeployFee(bytes calldata, uint256, bytes32, bool, bytes[] memory, bytes[] memory, uint8[] memory)
+        external
+        pure
+        returns (uint256[] memory fees)
+    {
         fees = new uint256[](4);
         return fees;
     }


### PR DESCRIPTION
* Adds a function to add a deployment target using the sygma domain ID
* Adds an internal function to get the deployment target string from the
  domain ID since this makes it easier to use existing code to not
  change any behaviour whatsoever.
* Added a storage mapping variable to store the mapping of domainId x
  deployment target name.
* Copied over testAddDeploymentTargetWithArgsAnvil into testAddDeploymentTargetByDomainIdWithArgsAnvil
  changing only the call to the function so that it uses the domain ID
  now.
